### PR TITLE
Update spkgbuild

### DIFF
--- a/core/harfbuzz/spkgbuild
+++ b/core/harfbuzz/spkgbuild
@@ -3,7 +3,7 @@
 # makedepends	: icu
 
 name=harfbuzz
-version=1.7.5
+version=1.7.6
 release=1
 source=(http://www.freedesktop.org/software/$name/release/$name-$version.tar.bz2)
 


### PR DESCRIPTION
I think it will be necessary to rebuild freetype2 after the upgrading. 
Quoting blfs in freetype2 section: HarfBuzz-1.7.6 (first, install without it, after it is installed, reinstall FreeType-2.9),