### PR TITLE
Update spkgbuild

### DIFF
--- a/core/git/spkgbuild
+++ b/core/git/spkgbuild
@@ -3,7 +3,7 @@
 # makedepends	: python2
 
 name=git
-version=2.16.2
+version=2.16.3
 release=1
 source=(https://www.kernel.org/pub/software/scm/$name/$name-$version.tar.xz)
 


### PR DESCRIPTION
Note: have a look at postinstall instructions for conformity with blfs book update (docs etc...). Actual spkgbuild postinstall cmds still 
in order?