### PR TITLE
Update spkgbuild

### DIFF
--- a/core/gst-plugins-base/spkgbuild
+++ b/core/gst-plugins-base/spkgbuild
@@ -13,7 +13,8 @@ build() {
 	cd $name-$version
 
 	./configure --prefix=/usr \
-		    --with-package-name="GStreamer Base Plugins $version (Nyx)"
+		    --with-package-name="GStreamer Base Plugins $version (Nyx)" \
+		    --disable-examples
 	make
 	make DESTDIR=$PKG install
 }


### PR DESCRIPTION
The make phase locks with an error message during gl examples building: doesn't find -lgstvideo-1.0.