### PR TITLE
Update spkgbuild i3 necessary to keep doc

### DIFF
--- a/extra/i3/spkgbuild
+++ b/extra/i3/spkgbuild
@@ -26,5 +26,5 @@ build() {
 	make
 	make DESTDIR=$PKG install
 
-	rm -r $PKG/usr/share/doc
+#	rm -r $PKG/usr/share/doc
 }


### PR DESCRIPTION
Necessary to keep the doc for compiling. Otherwise the pkg isn't building to the end.